### PR TITLE
Update mobile apps to use Reliable SIM Management conventions like the console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jdk:
 
 env:
   global:
-    - ANDROID_COMPILE_API_LEVEL=28
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
+    - ANDROID_COMPILE_API_LEVEL=30
+    - ANDROID_BUILD_TOOLS_VERSION=29.0.2
 
 android:
   components:
@@ -32,7 +32,6 @@ android:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
-
 
 script:
   - ./gradlew :cloudsdk:assembleDebug :cloudsdk:testDebugUnitTest :cloudsdk:jacocoTestReport 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ android:
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 
+before_install:
+  - yes | sdkmanager "platforms;android-30"
+  - yes | sdkmanager "build-tools;29.0.2"
+
 script:
   - ./gradlew :cloudsdk:assembleDebug :cloudsdk:testDebugUnitTest :cloudsdk:jacocoTestReport 
   - ./gradlew :cloudsdk:coveralls

--- a/mesh/src/main/java/io/particle/mesh/setup/flow/Errors.kt
+++ b/mesh/src/main/java/io/particle/mesh/setup/flow/Errors.kt
@@ -194,13 +194,13 @@ class StickerErrorException(cause: Throwable? = null) : MeshSetupFlowException(
 
 class FailedToActivateSimException(severity: ExceptionType, cause: Throwable? = null) : MeshSetupFlowException(
     cause,
-    userFacingMessage = "SIM activation is taking longer than expected. Please retry your SIM activation. If you have retried multiple times, please contact support.",
+    userFacingMessage = "SIM activation is ongoing and taking a long time to finish. Wait for it to complete and try again.",
     severity = severity
 )
 
 
 class FailedToDeactivateSimException : MeshSetupFlowException(
-    userFacingMessage = "SIM deactivation is taking longer than expected. Please retry your SIM deactivation. If you have retried multiple times, please contact support.",
+    userFacingMessage = "SIM deactivation is ongoing and taking a long time to finish. Wait for it to complete and try again.",
     severity = ERROR_FATAL
 )
 


### PR DESCRIPTION
`doActivateSim()` throws an exception when the status is not 504 so the previous code to handle 504 never ran. When a SIM took too long to activate, the setup failed with `Setup has encountered an error and cannot continue` (default error in `MeshFlowExecutor.kt`)

Use the `retrySimAction` helper when activating a SIM as part of the Gen 3 setup. This will retry 4 times and if the operation isn't complete, it will show `SIM activation is ongoing and taking a long time to finish. Wait for it to complete and try again.`

Steps to test:
- Have a Boron LTE on your Particle account
- Unclaim the Boron LTE from the Console device page
- Release the SIM for the Boron LTE from the Console SIM page
- Wait until the SIM disappears from the Console SIM page (it will be in state Updating for 2-10 minutes)
- Set up the Boron LTE through the Gen 3 setup with the Android app
- Expect to see `SIM activation is ongoing and taking a long time to finish. Wait for it to complete and try again.` and setup close
