### PR TITLE
Fix issue 97

### DIFF
--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/SuccessActivity.java
@@ -109,7 +109,7 @@ public class SuccessActivity extends BaseActivity {
                 finishSetup(v.getContext(), deviceNameView.getText().toString(), true);
             }
         } else {
-            leaveActivity(v.getContext(), false);
+            leaveActivity(v.getContext(), isSuccess);
         }
     }
 


### PR DESCRIPTION
Fix regarding issue https://github.com/particle-iot/particle-android/issues/97
This boolean should not be hard coded to `false` because if setup is initiated with wi-fi configuration only, it will always fail. Changing the boolean to reflect actual status fixes the problem.